### PR TITLE
Fixed failing tests for loading a yaml config file

### DIFF
--- a/spec/configliere/config_file_spec.rb
+++ b/spec/configliere/config_file_spec.rb
@@ -12,7 +12,7 @@ describe Configliere::ConfigFile do
 
   describe 'loading a yaml config file' do
     before do
-      @fake_file = '{ :my_param: val_from_file }'
+      @fake_file = ':my_param: val_from_file'
     end
 
     describe 'successfully' do


### PR DESCRIPTION
The fake was returning a ruby hash rather than yaml.
