### PR TITLE
tests pass using bundler, once yaml and multi_json are properly required

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -63,7 +63,7 @@ For an extensive usage in production, see the "wukong gem.":http://github.com/mr
 
 h2. Notice
 
-Configliere 4.x now has 100% spec coverage, more powerful commandline handling, zero required dependencies. However, it also strips out several obscure features and much magical code, which breaks said obscure features and magic-dependent code. See the "CHANGELOG.":CHANGELOG.textile for details as you upgrade.
+Configliere 4.x now has 100% spec coverage, more powerful commandline handling, and minimal required dependencies. However, it also strips out several obscure features and much magical code, which breaks said obscure features and magic-dependent code. See the "CHANGELOG.":CHANGELOG.textile for details as you upgrade.
 
 h2. Design goals:
 

--- a/lib/configliere.rb
+++ b/lib/configliere.rb
@@ -1,6 +1,10 @@
 require 'date'                      # type conversion
 require 'time'                      # type conversion
 require 'fileutils'                 # so save! can mkdir
+
+require 'multi_json'
+require 'yaml'
+
 require 'configliere/deep_hash'     # magic hash for params
 require 'configliere/param'         # params container
 require 'configliere/define'        # define param behavior

--- a/lib/configliere/config_file.rb
+++ b/lib/configliere/config_file.rb
@@ -48,7 +48,6 @@ module Configliere
     end
 
     def read_yaml yaml_str, options={}
-      require 'yaml'
       new_data = YAML.load(yaml_str) || {}
       # Extract the :env (production/development/etc)
       if options[:env]
@@ -58,11 +57,7 @@ module Configliere
       self
     end
 
-    #
-    # we depend on you to require some sort of JSON
-    #
     def read_json json_str, options={}
-      require 'multi_json'
       new_data = MultiJson.load(json_str) || {}
       # Extract the :env (production/development/etc)
       if options[:env]


### PR DESCRIPTION
When running tests using `bundle exec rake rspec`, the require statement for `yaml` is missing and causing tests to fail. 

The require statement for this library is contained within the `ConfigFile#read_yaml` method; similarly the require statement for `multi_json` is contained in `ConfigFile#read_json`. Since both methods are top-level features, and are fully tested, these require statements should be moved into the main class loader. This will cause no dependency issues as `yaml` has been a standard ruby library since 1.8.7 and `multi_json` is listed as a dependency in both the Gemfile and the gemspec. 

Break the silence, yo.
