### PR TITLE
Flags

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -63,7 +63,7 @@ For an extensive usage in production, see the "wukong gem.":http://github.com/mr
 
 h2. Notice
 
-Configliere 4.x now has 100% spec coverage, more powerful commandline handling, zero required dependencies. However, it also strips out several obscure features and much magical code, which breaks said obscure features and magic-dependent code. See the "CHANGELOG.":CHANGELOG.textile for details as you upgrade.
+Configliere 4.x now has 100% spec coverage, more powerful commandline handling, and minimal required dependencies. However, it also strips out several obscure features and much magical code, which breaks said obscure features and magic-dependent code. See the "CHANGELOG.":CHANGELOG.textile for details as you upgrade.
 
 h2. Design goals:
 

--- a/lib/configliere.rb
+++ b/lib/configliere.rb
@@ -1,6 +1,10 @@
 require 'date'                      # type conversion
 require 'time'                      # type conversion
 require 'fileutils'                 # so save! can mkdir
+
+require 'multi_json'
+require 'yaml'
+
 require 'configliere/deep_hash'     # magic hash for params
 require 'configliere/param'         # params container
 require 'configliere/define'        # define param behavior

--- a/lib/configliere/commandline.rb
+++ b/lib/configliere/commandline.rb
@@ -70,7 +70,7 @@ module Configliere
         # -a val
         when arg =~ /\A-(\w)\z/
           flag = find_param_for_flag($1)
-          unless flag then @unknown_argvs << flag ; next ; end
+          unless flag then @unknown_argvs << $1 ; next ; end
           if (not args.empty?) && (args.first !~ /\A-/)
             val = args.shift
           else
@@ -80,7 +80,7 @@ module Configliere
         # -a=val
         when arg =~ /\A-(\w)=(.*)\z/
           flag, val = [find_param_for_flag($1), $2]
-          unless flag then @unknown_argvs << flag ; next ; end
+          unless flag then @unknown_argvs << $1 ; next ; end
           self[flag] = parse_value(val)
         else
           self.rest << arg

--- a/lib/configliere/config_file.rb
+++ b/lib/configliere/config_file.rb
@@ -48,7 +48,6 @@ module Configliere
     end
 
     def read_yaml yaml_str, options={}
-      require 'yaml'
       new_data = YAML.load(yaml_str) || {}
       # Extract the :env (production/development/etc)
       if options[:env]
@@ -58,11 +57,7 @@ module Configliere
       self
     end
 
-    #
-    # we depend on you to require some sort of JSON
-    #
     def read_json json_str, options={}
-      require 'multi_json'
       new_data = MultiJson.load(json_str) || {}
       # Extract the :env (production/development/etc)
       if options[:env]

--- a/spec/configliere/commandline_spec.rb
+++ b/spec/configliere/commandline_spec.rb
@@ -103,6 +103,12 @@ describe "Configliere::Commandline" do
       @config.should == { :date => 'new_val', :cat => true }
     end
 
+    it 'stores unknown flags with values in unknown_argvs' do
+      ::ARGV.replace ['-f=path/to/file']
+      @config.resolve!
+      @config.unknown_argvs.should == ['f']
+    end
+
     it 'accepts a space-separated value (-d new_val)' do
       ::ARGV.replace ['-d', 'new_val', '-c', '-p']
       @config.resolve!
@@ -122,6 +128,12 @@ describe "Configliere::Commandline" do
       lambda{ @config.resolve! }.should_not raise_error(Configliere::Error)
       @config.should == { :date => true, :cat => true }
       @config.unknown_argvs.should == ['z']
+    end
+
+    it 'stores unknown single-letter flags in unknown_argvs, even when singular' do
+      ::ARGV.replace ['-T']
+      lambda{ @config.resolve! }.should_not raise_error(Configliere::Error)
+      @config.unknown_argvs.should == ['T']
     end
   end
 


### PR DESCRIPTION
The logic:

``` ruby
unless flag then @unknown_argvs << flag ; next ; end
```

does not work correctly. Only when the condition is met will `flag` be added to `@unknown_argvs`, however, in order for the condition to _be_ met, `flag` must be `nil`, which then stores a `nil` value in `@unknown_argvs`. This will not help indicate any unknown flags that may have been passed on the command line.
