### PR TITLE
bumped highline version

### DIFF
--- a/configliere.gemspec
+++ b/configliere.gemspec
@@ -83,14 +83,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<multi_json>, ["~> 1.10.1"])
-      s.add_runtime_dependency(%q<highline>, ["1.5.2"])
+      s.add_runtime_dependency(%q<highline>, [">= 1.6"])
       s.add_dependency(%q<rake>, ["10.1.1"])
       s.add_dependency(%q<yard>, ["0.8.7.3"])
       s.add_dependency(%q<rspec>, ["~> 2.14"])
       s.add_dependency(%q<jeweler>, ["1.8.4"])
     else
       s.add_dependency(%q<multi_json>, ["~> 1.10.1"])
-      s.add_dependency(%q<highline>, [">= 1.5.2"])
+      s.add_dependency(%q<highline>, [">= 1.6"])
       s.add_dependency(%q<bundler>, ["~> 1.1"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0.7"])
@@ -99,7 +99,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<multi_json>, ["~> 1.10.1"])
-    s.add_dependency(%q<highline>, [">= 1.5.2"])
+    s.add_dependency(%q<highline>, [">= 1.6"])
     s.add_dependency(%q<bundler>, ["~> 1.1"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0.7"])
@@ -107,4 +107,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<jeweler>, [">= 1.6"])
   end
 end
-


### PR DESCRIPTION
Using highline 1.5 makes this gem incompatible with Commander which requires 1.6 (1.5/6 are not compatible it seems).  I changed the version and the tests pass so I am assuming this works.
